### PR TITLE
Fix for alias_method

### DIFF
--- a/lib/trailblazer/developer/wtf.rb
+++ b/lib/trailblazer/developer/wtf.rb
@@ -4,7 +4,8 @@ module Trailblazer::Developer
   def wtf(activity, args)
     Wtf.invoke(activity, args)
   end
-  alias_method :wtf?, :wtf
+
+  singleton_class.alias_method :wtf?, :wtf
 
   module Wtf
     module_function

--- a/test/trace/wtf_test.rb
+++ b/test/trace/wtf_test.rb
@@ -50,4 +50,8 @@ class TraceWtfTest < Minitest::Spec
 
     pp ctx
   end
+
+  it "has alias to `wtf` as `wtf?`" do
+    assert_equal Dev.method(:wtf), Dev.method(:wtf?)
+  end
 end


### PR DESCRIPTION
`alias_method` doesn't seem to work when `module_function` is used for a method.
Use explicit singleton class syntax instead.