### PR TITLE
Print wtf trace in all cases and not only on exception

### DIFF
--- a/lib/trailblazer/developer.rb
+++ b/lib/trailblazer/developer.rb
@@ -6,6 +6,7 @@ module Trailblazer
   end
 end
 
+require "trailblazer/developer/config"
 require "trailblazer/developer/wtf"
 require "trailblazer/developer/generate"
 require "trailblazer/developer/render/circuit"

--- a/lib/trailblazer/developer/config.rb
+++ b/lib/trailblazer/developer/config.rb
@@ -1,0 +1,30 @@
+module Trailblazer::Developer
+  # {config} gives global settings for Developer
+  # Trailblazer::Developer.configure do |config|
+  #   config.trace_color_map[Trailblazer::Activity::Right] = :green
+  #   config.trace_color_map.default = :green
+  # end
+
+  class << self
+    def configure
+      yield config
+    end
+
+    def config
+      @config ||= Config.new
+    end
+  end
+
+  class Config
+    attr_reader :trace_color_map
+
+    def initialize
+      @trace_color_map = {
+        Trailblazer::Activity::Right => :green,
+        Trailblazer::Activity::Left  => :brown
+      }
+
+      @trace_color_map.default = :green
+    end
+  end
+end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class ConfigurationTest < Minitest::Spec
+  describe "trace_color_map" do
+    after do
+      Trailblazer::Developer.config.trace_color_map.default = :green
+      Trailblazer::Developer.config.trace_color_map[Trailblazer::Activity::Right] = :green
+    end
+
+    it "sets default" do
+      assert_equal Trailblazer::Developer.config.trace_color_map.default, :green
+      assert_equal Trailblazer::Developer.config.trace_color_map, {
+        Trailblazer::Activity::Right => :green,
+        Trailblazer::Activity::Left  => :brown
+      }
+    end
+
+    it "overrides defaults via block" do
+      Trailblazer::Developer.configure { |c| c.trace_color_map.default = :cyan }
+      assert_equal Trailblazer::Developer.config.trace_color_map.default, :cyan
+
+      Trailblazer::Developer.configure do |config|
+        config.trace_color_map[Trailblazer::Activity::Right] = :cyan
+      end
+      assert_equal Trailblazer::Developer.config.trace_color_map[Trailblazer::Activity::Right], :cyan
+    end
+  end
+end

--- a/trailblazer-developer.gemspec
+++ b/trailblazer-developer.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rubocop"
 
-  spec.add_dependency "trailblazer-activity", "~> 0.8"
+  spec.add_dependency "trailblazer-activity", ">= 0.8.4"
   spec.add_dependency "trailblazer-activity-dsl-linear"
   spec.add_dependency "representable"
 end


### PR DESCRIPTION
- Print activity trace no matter what (On success, failure or in exception)
- Color current step as per it's `output` and `previous/next step's` status 

![Screenshot from 2019-08-19 10-06-21](https://user-images.githubusercontent.com/6301525/63315186-d8cd8800-c327-11e9-9eb4-ff33cbdcaacf.png)