### PR TITLE
Allow focusing on selective steps or ctx in wtf :tada:

### DIFF
--- a/lib/trailblazer/developer.rb
+++ b/lib/trailblazer/developer.rb
@@ -9,6 +9,7 @@ end
 require "trailblazer/developer/wtf"
 require "trailblazer/developer/trace"
 require "trailblazer/developer/trace/present"
+require "trailblazer/developer/trace/focusable"
 require "trailblazer/developer/generate"
 require "trailblazer/developer/render/circuit"
 require "trailblazer/developer/render/linear"

--- a/lib/trailblazer/developer/trace/focusable.rb
+++ b/lib/trailblazer/developer/trace/focusable.rb
@@ -1,0 +1,74 @@
+require 'hirb'
+
+module Trailblazer
+  module Developer
+    module Trace
+
+      module Focusable
+        module_function
+
+        # Get inspect of {focus_on.variables} or current {ctx}
+        def capture_variables_from(ctx, focus_on:, **)
+          variables = (selected = focus_on[:variables]).any? ? selected : ctx.keys
+
+          variables.each_with_object({}) do |variable, result|
+            if variable.is_a?(Proc) # To allow deep key access from ctx
+              result[:Custom]   = variable.call(ctx).inspect
+            else
+              result[variable]  = ctx[variable].inspect
+            end
+          end
+        end
+
+        # Generate Hirb's vertical table nodes from captured ctx of each step
+        # |-- some step name
+        # |   |-- ********** Input **********
+        #    message: "WTF!"
+        #        seq: []
+        # |   `-- ********** Output **********
+        #    message: "WTF!"
+        #        seq: [:a]
+        def tree_nodes_for(level, input:, output:, **options)
+          input_output_nodes = { Input: input, Output: output }.compact.collect do |table_header, entity|
+            next unless Array( entity.data[:focused_variables] ).any?
+
+            table = vertical_table_for(entity.data[:focused_variables], table_header: table_header)
+            Present::TreeNodes::Node.new(level + 1, table, input, output, options).freeze
+          end
+
+          input_output_nodes.compact
+        end
+
+        # @private
+        def vertical_table_for(focused_variables, table_header:)
+          patched_vertical_table.render(
+            Array[ focused_variables ],
+            description: nil,
+            table_header: table_header, # Custom option, not from Hirb
+          )
+        end
+
+        # Overrding `Hirb::Helpers::VerticalTable#render_rows` because there is no option
+        # to customize vertical table's row header :(
+        # We need it to print if given entity is Input/Output
+        #
+        # @private
+        def patched_vertical_table
+          table = Class.new(Hirb::Helpers::VerticalTable)
+
+          table.send(:define_method, :render_rows) do
+            longest_header = Hirb::String.size (@headers.values.sort_by {|e| Hirb::String.size(e) }.last || '')
+            stars = "*" * [(longest_header + (longest_header / 2)), 3].max
+
+            @rows.map do |row|
+              "#{stars} #{@options[:table_header]} #{stars}\n" +
+                @fields.map{ |f| "#{Hirb::String.rjust(@headers[f], longest_header)}: #{row[f]}" }.join("\n")
+            end
+          end
+
+          table
+        end
+      end
+    end
+  end
+end

--- a/test/trace/stack_test.rb
+++ b/test/trace/stack_test.rb
@@ -5,6 +5,8 @@ class StackTest < Minitest::Spec
     stack = Dev::Trace::Stack.new
     stack.indent!
     stack << 1
+    stack.top.must_equal 1
+
     stack << 2
     stack.indent!
     stack << 3
@@ -19,6 +21,8 @@ class StackTest < Minitest::Spec
     stack << 9
     stack << 10
     # stack.unindent!
+
+    stack.top.must_equal 10
 
     stack.to_a.inspect.must_equal %{<Level>[<Level>[1, 2, <Level>[3, 4, <Level>[5, 6], 7, 8], 9, 10]]}
   end

--- a/test/trace/wtf_test.rb
+++ b/test/trace/wtf_test.rb
@@ -46,14 +46,14 @@ class TraceWtfTest < Minitest::Spec
     end
 
     output.gsub(/0x\w+/, "").must_equal %{`-- #<Class:>
-   |-- \e[32mStart.default\e[0m
-   |-- \e[32m#<Method: #<Class:>.a>\e[0m
-   |-- #<Class:>
-   |   |-- \e[32mStart.default\e[0m
-   |   |-- \e[32m#<Method: #<Class:>.b>\e[0m
-   |   |-- #<Class:>
-   |   |   |-- \e[32mStart.default\e[0m
-   |   |   |-- \e[1m\e[31m#<Method: #<Class:>.c>\e[0m\e[22m
+    |-- \e[32mStart.default\e[0m
+    |-- \e[32m#<Method: #<Class:>.a>\e[0m
+    `-- #<Class:>
+        |-- \e[32mStart.default\e[0m
+        |-- \e[32m#<Method: #<Class:>.b>\e[0m
+        `-- #<Class:>
+            |-- \e[32mStart.default\e[0m
+            `-- \e[1m\e[31m#<Method: #<Class:>.c>\e[0m\e[22m
 }
   end
 
@@ -64,17 +64,17 @@ class TraceWtfTest < Minitest::Spec
     end
 
     output.gsub(/0x\w+/, "").must_equal %{`-- #<Class:>
-   |-- \e[32mStart.default\e[0m
-   |-- \e[32m#<Method: #<Class:>.a>\e[0m
-   |-- #<Class:>
-   |   |-- \e[32mStart.default\e[0m
-   |   |-- \e[32m#<Method: #<Class:>.b>\e[0m
-   |   |-- #<Class:>
-   |   |   |-- \e[32mStart.default\e[0m
-   |   |   |-- \e[33m#<Method: #<Class:>.c>\e[0m
-   |   |   `-- End.failure
-   |   `-- End.failure
-   `-- End.failure
+    |-- \e[32mStart.default\e[0m
+    |-- \e[32m#<Method: #<Class:>.a>\e[0m
+    |-- #<Class:>
+    |   |-- \e[32mStart.default\e[0m
+    |   |-- \e[32m#<Method: #<Class:>.b>\e[0m
+    |   |-- #<Class:>
+    |   |   |-- \e[32mStart.default\e[0m
+    |   |   |-- \e[33m#<Method: #<Class:>.c>\e[0m
+    |   |   `-- End.failure
+    |   `-- End.failure
+    `-- End.failure
 }
   end
 
@@ -85,20 +85,20 @@ class TraceWtfTest < Minitest::Spec
     end
 
     output.gsub(/0x\w+/, "").must_equal %{`-- #<Class:>
-   |-- \e[32mStart.default\e[0m
-   |-- \e[32m#<Method: #<Class:>.a>\e[0m
-   |-- #<Class:>
-   |   |-- \e[32mStart.default\e[0m
-   |   |-- \e[32m#<Method: #<Class:>.b>\e[0m
-   |   |-- #<Class:>
-   |   |   |-- \e[32mStart.default\e[0m
-   |   |   |-- \e[32m#<Method: #<Class:>.c>\e[0m
-   |   |   |-- \e[32m#<Method: #<Class:>.cc>\e[0m
-   |   |   `-- End.success
-   |   |-- \e[32m#<Method: #<Class:>.bb>\e[0m
-   |   `-- End.success
-   |-- \e[32m#<Method: #<Class:>.aa>\e[0m
-   `-- End.success
+    |-- \e[32mStart.default\e[0m
+    |-- \e[32m#<Method: #<Class:>.a>\e[0m
+    |-- #<Class:>
+    |   |-- \e[32mStart.default\e[0m
+    |   |-- \e[32m#<Method: #<Class:>.b>\e[0m
+    |   |-- #<Class:>
+    |   |   |-- \e[32mStart.default\e[0m
+    |   |   |-- \e[32m#<Method: #<Class:>.c>\e[0m
+    |   |   |-- \e[32m#<Method: #<Class:>.cc>\e[0m
+    |   |   `-- End.success
+    |   |-- \e[32m#<Method: #<Class:>.bb>\e[0m
+    |   `-- End.success
+    |-- \e[32m#<Method: #<Class:>.aa>\e[0m
+    `-- End.success
 }
   end
 
@@ -114,17 +114,164 @@ class TraceWtfTest < Minitest::Spec
     end
 
     output.gsub(/0x\w+/, "").must_equal %{`-- #<Class:>
-   |-- \e[36mStart.default\e[0m
-   |-- \e[36m#<Method: #<Class:>.a>\e[0m
-   |-- #<Class:>
-   |   |-- \e[36mStart.default\e[0m
-   |   |-- \e[36m#<Method: #<Class:>.b>\e[0m
-   |   |-- #<Class:>
-   |   |   |-- \e[36mStart.default\e[0m
-   |   |   |-- \e[31m#<Method: #<Class:>.c>\e[0m
-   |   |   `-- End.failure
-   |   `-- End.failure
-   `-- End.failure
+    |-- \e[36mStart.default\e[0m
+    |-- \e[36m#<Method: #<Class:>.a>\e[0m
+    |-- #<Class:>
+    |   |-- \e[36mStart.default\e[0m
+    |   |-- \e[36m#<Method: #<Class:>.b>\e[0m
+    |   |-- #<Class:>
+    |   |   |-- \e[36mStart.default\e[0m
+    |   |   |-- \e[31m#<Method: #<Class:>.c>\e[0m
+    |   |   `-- End.failure
+    |   `-- End.failure
+    `-- End.failure
+}
+  end
+
+  it "captures input & output for only given step and not others" do
+    _, (_, flow_options), _ = Trailblazer::Developer.wtf?(
+      alpha,
+      [
+        { seq: [], message: 'WTF!' },
+        { focus_on: { steps: alpha.method(:a) } }
+      ],
+    )
+
+    nested = flow_options[:stack].to_a.last
+    tasks = nested.select{ |e| e.is_a?(Dev::Trace::Level) } # exclude ends
+
+    # Trace::Entity::Input & Trace::Entity::Output for
+    # task `:a` must contain {focused_variables} and not others
+    tasks.each do |(input, *remainings)|
+      if input.task.inspect.gsub(/0x\w+/, "").include?('#<Method: #<Class:>.a>>')
+        input.data.keys.must_include(:focused_variables)
+      else
+        input.data.keys.wont_include(:focused_variables)
+      end
+
+      output = remainings.last
+
+      if output.task.inspect.gsub(/0x\w+/, "").include?('#<Method: #<Class:>.a>>')
+        output.data.keys.must_include(:focused_variables)
+      else
+        output.data.keys.wont_include(:focused_variables)
+      end
+    end
+  end
+
+  it "captures input & output for given step and ctx (captures whole ctx by default)" do
+    output, _ = capture_io do
+      Trailblazer::Developer.wtf?(
+        alpha,
+        [
+          { seq: [], message: 'WTF!' },
+          { focus_on: { steps: alpha.method(:a) } }
+        ],
+      )
+    end
+
+    output.gsub(/0x\w+/, "").must_equal %{`-- #<Class:>
+    |-- \e[32mStart.default\e[0m
+    |-- \e[32m#<Method: #<Class:>.a>\e[0m
+    |   |-- \e[32m********** Input **********
+            message: \"WTF!\"
+                seq: []\e[0m
+    |   `-- \e[32m********** Output **********
+            message: \"WTF!\"
+                seq: [:a]\e[0m
+    |-- #<Class:>
+    |   |-- \e[32mStart.default\e[0m
+    |   |-- \e[32m#<Method: #<Class:>.b>\e[0m
+    |   |-- #<Class:>
+    |   |   |-- \e[32mStart.default\e[0m
+    |   |   |-- \e[32m#<Method: #<Class:>.c>\e[0m
+    |   |   |-- \e[32m#<Method: #<Class:>.cc>\e[0m
+    |   |   `-- End.success
+    |   |-- \e[32m#<Method: #<Class:>.bb>\e[0m
+    |   `-- End.success
+    |-- \e[32m#<Method: #<Class:>.aa>\e[0m
+    `-- End.success
+}
+  end
+
+  it "captures input & output inspect for given step and variable within ctx" do
+    output, _ = capture_io do
+      Trailblazer::Developer.wtf?(
+        alpha,
+        [
+          { seq: [], message: 'WTF!', nested: { message: 'Dude!' } },
+          {
+            focus_on: {
+              steps: alpha.method(:a),
+              variables: :message
+            },
+          }
+        ],
+      )
+    end
+
+    output.gsub(/0x\w+/, "").must_equal %{`-- #<Class:>
+    |-- \e[32mStart.default\e[0m
+    |-- \e[32m#<Method: #<Class:>.a>\e[0m
+    |   |-- \e[32m********** Input **********
+            message: \"WTF!\"\e[0m
+    |   `-- \e[32m********** Output **********
+            message: \"WTF!\"\e[0m
+    |-- #<Class:>
+    |   |-- \e[32mStart.default\e[0m
+    |   |-- \e[32m#<Method: #<Class:>.b>\e[0m
+    |   |-- #<Class:>
+    |   |   |-- \e[32mStart.default\e[0m
+    |   |   |-- \e[32m#<Method: #<Class:>.c>\e[0m
+    |   |   |-- \e[32m#<Method: #<Class:>.cc>\e[0m
+    |   |   `-- End.success
+    |   |-- \e[32m#<Method: #<Class:>.bb>\e[0m
+    |   `-- End.success
+    |-- \e[32m#<Method: #<Class:>.aa>\e[0m
+    `-- End.success
+}
+  end
+
+  it "captures input & output for given 1/more steps and selected variables witin ctx" do
+    output, _ = capture_io do
+      Trailblazer::Developer.wtf?(
+        alpha,
+        [
+          { seq: [], message: 'WTF!', nested: { message: 'Dude!' } },
+          {
+            focus_on: {
+              steps: [alpha.method(:a)],
+              variables: [
+                :message, # symbol for top level key access
+                ->(ctx) { ctx[:nested][:message] }, # procs can be used for deep access
+              ]
+            },
+          }
+        ],
+      )
+    end
+
+    output.gsub(/0x\w+/, "").must_equal %{`-- #<Class:>
+    |-- \e[32mStart.default\e[0m
+    |-- \e[32m#<Method: #<Class:>.a>\e[0m
+    |   |-- \e[32m********** Input **********
+             Custom: \"Dude!\"
+            message: \"WTF!\"\e[0m
+    |   `-- \e[32m********** Output **********
+             Custom: \"Dude!\"
+            message: \"WTF!\"\e[0m
+    |-- #<Class:>
+    |   |-- \e[32mStart.default\e[0m
+    |   |-- \e[32m#<Method: #<Class:>.b>\e[0m
+    |   |-- #<Class:>
+    |   |   |-- \e[32mStart.default\e[0m
+    |   |   |-- \e[32m#<Method: #<Class:>.c>\e[0m
+    |   |   |-- \e[32m#<Method: #<Class:>.cc>\e[0m
+    |   |   `-- End.success
+    |   |-- \e[32m#<Method: #<Class:>.bb>\e[0m
+    |   `-- End.success
+    |-- \e[32m#<Method: #<Class:>.aa>\e[0m
+    `-- End.success
 }
   end
 

--- a/test/trace_test.rb
+++ b/test/trace_test.rb
@@ -21,10 +21,10 @@ class TraceTest < Minitest::Spec
     output = output.gsub(/0x\w+/, "").gsub(/0x\w+/, "").gsub(/@.+_test/, "")
 
     output.must_equal %{`-- #<Trailblazer::Activity:>
-   |-- Start.default
-   |-- B
-   |-- C
-   `-- End.success}
+    |-- Start.default
+    |-- B
+    |-- C
+    `-- End.success}
   end
 
   it "allows nested tracing" do
@@ -40,15 +40,44 @@ class TraceTest < Minitest::Spec
     puts output = output.gsub(/0x\w+/, "").gsub(/0x\w+/, "").gsub(/@.+_test/, "")
 
     output.must_equal %{`-- #<Trailblazer::Activity:>
-   |-- Start.default
-   |-- B
-   |-- D
-   |   |-- Start.default
-   |   |-- B
-   |   |-- C
-   |   `-- End.success
-   |-- E
-   `-- End.success}
+    |-- Start.default
+    |-- B
+    |-- D
+    |   |-- Start.default
+    |   |-- B
+    |   |-- C
+    |   `-- End.success
+    |-- E
+    `-- End.success}
+  end
+
+  it "collects stack entity data from :data collector" do
+    stack, signal, * = Dev::Trace.invoke(bc, [ { seq: [] } ])
+
+    nested = stack.to_a.first
+
+    nested.first.data.must_equal({ ctx: { seq: [:b, :c] }, task_name: bc })
+    nested.last.data.must_equal({ ctx: { seq: [:b, :c] }, signal: signal })
+  end
+
+  it "allows to inject custom :data collector" do
+    input_collector = ->(wrap_config, (ctx, _), _) { { ctx: ctx, something: :else } }
+    ouput_collector = ->(wrap_config, (ctx, _), _) { { ctx: ctx, signal: wrap_config[:return_signal] } }
+
+    stack, signal, * = Dev::Trace.invoke(
+      bc,
+      [
+        { seq: [] },
+        {
+          input_data_collector: input_collector,
+          output_data_collector: ouput_collector,
+        }
+      ]
+    )
+
+    nested = stack.to_a.first
+    nested.first.data.must_equal({ ctx: { seq: [:b, :c] }, something: :else })
+    nested.last.data.must_equal({ ctx: { seq: [:b, :c] }, signal: signal })
   end
 
   it "Present allows to inject :renderer and pass through additional arguments to the renderer" do
@@ -63,8 +92,8 @@ class TraceTest < Minitest::Spec
       assert tree[position] == task_node
 
       [
-        task_node[:level],
-        %{#{task_node[:level]}/#{task_node[:input].task}/#{task_node[:output].data}/#{task_node[:name]}/#{task_node[:color]}}
+        task_node.level,
+        %{#{task_node.level}/#{task_node.input.task}/#{task_node.output.data[:signal]}/#{task_node.value}/#{task_node.color}}
       ]
     end
 
@@ -75,15 +104,15 @@ class TraceTest < Minitest::Spec
     output = output.gsub(/0x\w+/, "").gsub(/0x\w+/, "").gsub(/@.+_test/, "")
 
     output.must_equal %{`-- 1/#<Trailblazer::Activity:>/#<Trailblazer::Activity::End semantic=:success>/#<Trailblazer::Activity:>/pink
-   |-- 2/#<Trailblazer::Activity::Start semantic=:default>/Trailblazer::Activity::Right/Start.default/pink
-   |-- 2/#<Method: Trailblazer::Activity::Testing::Assertions::Implementing.b>/Trailblazer::Activity::Right/B/pink
-   `-- 2/#<Trailblazer::Activity:>/#<Trailblazer::Activity::End semantic=:success>/D/pink
-   |   |-- 3/#<Trailblazer::Activity::Start semantic=:default>/Trailblazer::Activity::Right/Start.default/pink
-   |   |-- 3/#<Method: Trailblazer::Activity::Testing::Assertions::Implementing.b>/Trailblazer::Activity::Right/B/pink
-   |   |-- 3/#<Method: Trailblazer::Activity::Testing::Assertions::Implementing.c>/Trailblazer::Activity::Right/C/pink
-   |   `-- 3/#<Trailblazer::Activity::End semantic=:success>/#<Trailblazer::Activity::End semantic=:success>/End.success/pink
-   |-- 2/#<Method: Trailblazer::Activity::Testing::Assertions::Implementing.f>/Trailblazer::Activity::Right/E/pink
-   `-- 2/#<Trailblazer::Activity::End semantic=:success>/#<Trailblazer::Activity::End semantic=:success>/End.success/pink}
+    |-- 2/#<Trailblazer::Activity::Start semantic=:default>/Trailblazer::Activity::Right/Start.default/pink
+    |-- 2/#<Method: Trailblazer::Activity::Testing::Assertions::Implementing.b>/Trailblazer::Activity::Right/B/pink
+    |-- 2/#<Trailblazer::Activity:>/#<Trailblazer::Activity::End semantic=:success>/D/pink
+    |   |-- 3/#<Trailblazer::Activity::Start semantic=:default>/Trailblazer::Activity::Right/Start.default/pink
+    |   |-- 3/#<Method: Trailblazer::Activity::Testing::Assertions::Implementing.b>/Trailblazer::Activity::Right/B/pink
+    |   |-- 3/#<Method: Trailblazer::Activity::Testing::Assertions::Implementing.c>/Trailblazer::Activity::Right/C/pink
+    |   `-- 3/#<Trailblazer::Activity::End semantic=:success>/#<Trailblazer::Activity::End semantic=:success>/End.success/pink
+    |-- 2/#<Method: Trailblazer::Activity::Testing::Assertions::Implementing.f>/Trailblazer::Activity::Right/E/pink
+    `-- 2/#<Trailblazer::Activity::End semantic=:success>/#<Trailblazer::Activity::End semantic=:success>/End.success/pink}
   end
 
   it "allows to inject custom :stack" do

--- a/trailblazer-developer.gemspec
+++ b/trailblazer-developer.gemspec
@@ -27,4 +27,5 @@ Gem::Specification.new do |spec|
   spec.add_dependency "trailblazer-activity", ">= 0.10.0", "< 1.0.0"
   spec.add_dependency "trailblazer-activity-dsl-linear"
   spec.add_dependency "representable"
+  spec.add_dependency "hirb"
 end


### PR DESCRIPTION
 **Summary**

- Allow input/output ctx to be shown in `wtf?` output by adding `focus_on` option
- `focus_on` contains list of steps and/or variables from ctx for which input/output needs to be shown.
- When `focus_on` contains only steps list, all `ctx ` is shown in the output.
- Otherwise selective variables can be passed. 

**Changes**
- Add Hirb back to render trace and also vertical table within trace.
- Print Input/Output sections only if `focus_on` mentions steps. This is done to avoid cluttering input/output all over console.
- Allow injecting custom data collector in `Trace::Stack`.

<img width="1382" alt="Screenshot 2020-01-12 at 12 08 57 AM" src="https://user-images.githubusercontent.com/6301525/72209071-aab43480-34d0-11ea-84a6-c32907de15b7.png">
