### PR TITLE
Fix circuit interface call definition

### DIFF
--- a/lib/trailblazer/developer/wtf.rb
+++ b/lib/trailblazer/developer/wtf.rb
@@ -14,13 +14,13 @@ module Trailblazer::Developer
 
     # Run {activity} with tracing enabled and inject a mutable {Stack} instance.
     # This allows to display the trace even when an exception happened
-    def invoke(activity, (ctx, flow_options), *circuit_options)
+    def invoke(activity, (ctx, flow_options), **circuit_options)
       activity, (ctx, flow_options), circuit_options = Wtf.arguments_for_trace(
-        activity, [ctx, flow_options], *circuit_options
+        activity, [ctx, flow_options], circuit_options
       )
 
       _returned_stack, signal, (ctx, flow_options) = Trace.invoke(
-        activity, [ctx, flow_options], *circuit_options
+        activity, [ctx, flow_options], circuit_options
       )
 
       return signal, [ctx, flow_options], circuit_options

--- a/test/trace/wtf_test.rb
+++ b/test/trace/wtf_test.rb
@@ -374,6 +374,24 @@ class TraceWtfTest < Minitest::Spec
 }
   end
 
+  it "supports circuit interface call definition and doesn't mutate any passed options" do
+    ctx = { seq: [] }
+    flow_options = { flow: true }
+    circuit_options = { circuit: true }
+
+    capture_io do
+      Trailblazer::Developer.wtf?(
+        alpha,
+        [ctx, flow_options],
+        circuit_options
+      )
+    end
+
+    _(ctx).must_equal({ seq: [:a, :b, :c, :cc, :bb, :aa] })
+    _(flow_options).must_equal({ flow: true })
+    _(circuit_options).must_equal({ circuit: true })
+  end
+
   it "has alias to `wtf` as `wtf?`" do
     assert_equal Dev.method(:wtf), Dev.method(:wtf?)
   end


### PR DESCRIPTION
`circuit_options` were being converted to Array because of single `*`