### PR TITLE
Upgrade activity, DSL & representer versions

### DIFF
--- a/trailblazer-developer.gemspec
+++ b/trailblazer-developer.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-line"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "trailblazer-activity", ">= 0.11.0", "< 1.0.0"
-  spec.add_dependency "trailblazer-activity-dsl-linear"
+  spec.add_dependency "trailblazer-activity", ">= 0.12.2", "< 0.13.0"
+  spec.add_dependency "trailblazer-activity-dsl-linear", ">= 0.4.1", "< 0.5.0"
   spec.add_dependency "representable"
   spec.add_dependency "hirb"
 end

--- a/trailblazer-developer.gemspec
+++ b/trailblazer-developer.gemspec
@@ -23,8 +23,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-line"
   spec.add_development_dependency "rake"
 
-  spec.add_dependency "trailblazer-activity", ">= 0.12.2", "< 0.13.0"
-  spec.add_dependency "trailblazer-activity-dsl-linear", ">= 0.4.1", "< 0.5.0"
-  spec.add_dependency "representable"
+  spec.add_dependency "trailblazer-activity", ">= 0.12.2", "< 1.0.0"
+  spec.add_dependency "trailblazer-activity-dsl-linear", ">= 0.4.1", "< 1.0.0"
+  spec.add_dependency "representable", ">= 3.1.1", "< 4.0.0"
   spec.add_dependency "hirb"
 end


### PR DESCRIPTION
This is required in order to use extracted `trailblazer-option`. Ref https://github.com/trailblazer/trailblazer-operation/pull/59